### PR TITLE
Removed the consent prompt is the scopes are already consented

### DIFF
--- a/IntuneAssistant.Infrastructure/Services/IdentityHelperService.cs
+++ b/IntuneAssistant.Infrastructure/Services/IdentityHelperService.cs
@@ -75,7 +75,7 @@ public sealed class IdentityHelperService : IIdentityHelperService
 
             try
             {
-                result = await app.AcquireTokenInteractive(AppConfiguration.GRAPH_INTERACTIVE_SCOPE).WithPrompt(Prompt.Consent).WithExtraScopesToConsent(AppConfiguration.GRAPH_INTERACTIVE_SCOPE).ExecuteAsync();
+                result = await app.AcquireTokenInteractive(AppConfiguration.GRAPH_INTERACTIVE_SCOPE).WithExtraScopesToConsent(AppConfiguration.GRAPH_INTERACTIVE_SCOPE).ExecuteAsync();
             }
             catch (MsalException msalException)
             {


### PR DESCRIPTION
By removing the WithPrompt, extra scopes are consented if needed. Otherwise the current consent will remain