### PR TITLE
Updated resource type from group policy configuration to administrative templates

### DIFF
--- a/IntuneAssistant.Infrastructure/Services/AssignmentsService.cs
+++ b/IntuneAssistant.Infrastructure/Services/AssignmentsService.cs
@@ -553,6 +553,7 @@ public sealed class AssignmentsService : IAssignmentsService
                     var sourcePolicy = groupPolicies.FirstOrDefault(p =>
                         nonAssigned != null &&
                         p.Id == policyId);
+                    var resourceType = ResourceTypes.GroupPolicyConfiguration.GetDescription();
                     AssignmentsResponseModel resource = new AssignmentsResponseModel
                     {
                         Id = sourcePolicy?.Id,
@@ -561,7 +562,7 @@ public sealed class AssignmentsService : IAssignmentsService
                     };
                     var assignmentResponse =
                         resource.Assignments.FirstOrDefault().ToAssignmentModel(resource,
-                            ResourceTypes.GroupPolicyConfiguration.ToString());
+                            resourceType);
                     results.Add(assignmentResponse);
                 }
 
@@ -571,6 +572,7 @@ public sealed class AssignmentsService : IAssignmentsService
                     var sourcePolicy = groupPolicies.FirstOrDefault(p =>
                         assignmentResponse != null &&
                         p.Id == assignmentResponse.Select(a => a.SourceId).FirstOrDefault());
+                    var resourceType = ResourceHelper.GetResourceTypeFromOdata(sourcePolicy.OdataType);
                     if (sourcePolicy is null)
                     {
                         var sourceId = assignmentResponse.Select(a => a.Id.Split('_')[0]);
@@ -591,7 +593,7 @@ public sealed class AssignmentsService : IAssignmentsService
                         {
                             var configurationPolicyAssignment =
                                 assignment.ToAssignmentModel(resource,
-                                    ResourceTypes.GroupPolicyConfiguration.ToString());
+                                    resourceType);
                             results.Add(configurationPolicyAssignment);
                         }
                     }
@@ -600,7 +602,7 @@ public sealed class AssignmentsService : IAssignmentsService
                         {
                             var configurationPolicyAssignment =
                                 assignment.ToAssignmentModel(resource,
-                                    ResourceTypes.GroupPolicyConfiguration.ToString());
+                                    resourceType);
                             results.Add(configurationPolicyAssignment);
                         }
                 }

--- a/IntuneAssistant/Enums/Enums.cs
+++ b/IntuneAssistant/Enums/Enums.cs
@@ -15,7 +15,7 @@ public enum ResourceTypes
 {
     [Description("Update Ring Configuration")]
     UpdateRingConfiguration,
-    [Description("Group Policy Configurations")]
+    [Description("Administrative Templates")]
     GroupPolicyConfiguration,
     [Description("Windows Compliance Policy")]
     WindowsCompliancePolicy,
@@ -59,6 +59,8 @@ public enum ResourceTypes
     DeviceLimitRestriction,
     [Description("macOS Custom Attributes")]
     MacOsCustomAttributes,
+    [Description("Windows Defender ATP Configuration")]
+    WindowsDefenderAdvancedThreatProtectionConfiguration,
     [Description("iOS LineOfBusiness Application Configuration")]
     IosLobAppConfiguration,
     [Description("Windows 32 LOB Application")]

--- a/IntuneAssistant/Helpers/ResourceHelper.cs
+++ b/IntuneAssistant/Helpers/ResourceHelper.cs
@@ -59,6 +59,8 @@ public static class ResourceHelper
                 return ResourceTypes.MacOsCustomConfiguration.GetDescription();
             case "#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration":
                 return ResourceTypes.AndroidWorkProfileGeneralDeviceConfiguration.GetDescription();
+            case "#microsoft.graph.windowsDefenderAdvancedThreatProtectionConfiguration":
+                return ResourceTypes.WindowsDefenderAdvancedThreatProtectionConfiguration.GetDescription();
             case "#microsoft.graph.windows10GeneralConfiguration" :
                 return "Windows 10 General Configuration";
             case "#microsoft.graph.windowsWifiConfiguration" :

--- a/IntuneAssistant/Models/GroupPolicyConfigurationModel.cs
+++ b/IntuneAssistant/Models/GroupPolicyConfigurationModel.cs
@@ -4,6 +4,8 @@ namespace IntuneAssistant.Models;
 
 public class GroupPolicyConfigurationModel
 {
+    [JsonProperty("@odata.type")]
+    public string OdataType { get; set; }
     public DateTime? CreatedDateTime { get; set; }
     public string Description { get; set; }
     public DateTime? LastModifiedDateTime { get; set; }


### PR DESCRIPTION
In the background administrative templates are categorised as group policy configuration. Changed the name into administrative templates