### PR TITLE
make the group members nullable

### DIFF
--- a/IntuneAssistant.WebInterface/src/schemas/groupSchema.tsx
+++ b/IntuneAssistant.WebInterface/src/schemas/groupSchema.tsx
@@ -21,7 +21,7 @@ const groupSchema = z.object({
     displayName: z.string().default(""),
     description: z.string().default(""),
     createdDateTime: z.string().default(""),
-    members: z.array(groupMemberSchema).default([]),
+    members: z.array(groupMemberSchema).nullable()
 });
 
 export type GroupModel = z.infer<typeof groupSchema>;


### PR DESCRIPTION
This is because of empty group returns in the case of all devices or all groups